### PR TITLE
Fix cross-compiling

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,70 @@
+#
+#    ICRAR - International Centre for Radio Astronomy Research
+#    (c) UWA - The University of Western Australia, 2014
+#    Copyright by UWA (in the framework of the ICRAR)
+#    All rights reserved
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+#    MA 02111-1307  USA
+#
+
+try:
+    import configparser
+except ImportError:
+    # Python 2 compatibility
+    import ConfigParser as configparser
+
+class setup_config(object):
+    """
+    Class to obtain configuration provided by the setup.cfg file used by
+    setuptools.
+    """
+
+    # Setuptools configuration file
+    SETUPTOOLS_CONFIG_FILE = 'setup.cfg'
+
+    # Cross-compiling section
+    BUILD_SECTION_NAME = 'build_info'
+
+    # Key name for specifying the target machine
+    MACHINE_KEY = 'machine'
+
+    def __init__(self):
+        """Initialize the configuration object"""
+        self._metadata = self._metadata_from_setupcfg(self.BUILD_SECTION_NAME)
+
+    def machine(self):
+        """Return the target machine name, or None if unknown"""
+        return self._get_cfg_value(self.MACHINE_KEY)
+
+    def _get_cfg_value(self, key):
+        """
+        Get a value associated with a key in the build section. Returns the
+        value, or None if unknown.
+        """
+        return self._metadata.get(key, None)
+
+    @classmethod
+    def _metadata_from_setupcfg(cls, section_name):
+        """Read the section of setup.cfg and return it as a dict"""
+        cfgparser = configparser.ConfigParser()
+        cfgparser.read(cls._get_cfg_filename())
+
+        return dict(cfgparser.items(section_name))
+
+    @classmethod
+    def _get_cfg_filename(cls):
+        """Get the file name of the setuptools cfg file"""
+        return cls.SETUPTOOLS_CONFIG_FILE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+# Cross-compiling configuration interface
+[build_info]
+
+# If cross-compiling, uncomment this and set it to the target machine name
+# (e.g. output of uname -m). If unset, the host machine type will be detected.
+#machine = x86_64

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,8 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
+from config import setup_config
+
 import glob
 import platform
 
@@ -33,7 +35,14 @@ crcmod_ext = Extension('crc32c',
                        language='c',
                        sources=['_crc32c.c', 'crc32c_sw.c'],
                        include_dirs=['.'])
-is_intel = platform.machine() in ['x86_64', 'AMD64']
+
+config = setup_config()
+
+machine = config.machine()
+if not machine:
+    machine = platform.machine()
+
+is_intel = machine in ['x86_64', 'AMD64']
 
 def get_extra_compile_args():
     # msvc is treated specially; otherwise we assume it's a unix compiler


### PR DESCRIPTION
## Description

When packaging crc32c for OpenEmbedded, I hit a build error. Cross-compiling fails because setup.py assumes it's running on the build machine. However, setup.py treats the command line as an opaque string, so we can't pass build system parameters normally.

Fortunately, setuptools uses a file called setup.cfg to set parameters. I added support for machine configuration in a new build system section.

## How has this been tested?

I created an OpenEmbedded recipe for crc32c:

```
DESCRIPTION = "A python package exposing the Intel SSE4.2 CRC32C instruction."
HOMEPAGE = "https://github.com/ICRAR/crc32c"
SECTION = "devel/python"
LICENSE = "LGPLv2"
LIC_FILES_CHKSUM = "file://setup.py;beginline=81;endline=81;md5=9e2e837c46174eef7a5db8b5c82dd34f"

SRC_URI[md5sum] = "9d799f4c836c003eb7fe23545c78e9f6"
SRC_URI[sha256sum] = "bdcd28f26b62838919480d465a0d166207a36c4f104102a0b6edf5b498544d36"

inherit pypi setuptools
```

Without the patch, I get this error:

```
| arm-sundstrom-linux-gnueabi-gcc: error: unrecognized command line option '-msse4.2'
| arm-sundstrom-linux-gnueabi-gcc: error: unrecognized command line option '-mpclmul'
```

Then I apply the patch, and append this to my recipe:

```
distutils_do_configure_prepend() {
    sed -i 's/#machine =.*/machine = ${MACHINE_ARCH}/' ${S}/setup.cfg
}
```

After the patch, crc32c can be used in the completed build.