### PR TITLE
[crc32c]:For non Intel machines default behavior is changed

### DIFF
--- a/_crc32c.c
+++ b/_crc32c.c
@@ -116,8 +116,12 @@ MOD_INIT(crc32c)
 	}
 
 	else {
-		PyErr_SetString(PyExc_ImportError, import_error_msg);
-		return MOD_VAL(NULL);
+#if PY_MAJOR_VERSION >= 3
+		PyRun_SimpleString("print('SSE4.2 extensions providing a crc32c hardware instruction are NOT available in your processor.  A software implementation of the same has been loaded instead.')");
+#else
+		PyRun_SimpleString("print 'SSE4.2 extensions providing a crc32c hardware instruction are NOT available in your processor.  A software implementation of the same has been loaded instead.'");
+#endif	
+		crc_fn = _crc32c_sw_slicing_by_8;
 	}
 
 	MOD_DEF(m, "crc32c", "wrapper for crc32c Intel instruction", CRC32CMethods);


### PR DESCRIPTION
A deafult software fallback is added for non Intel machines, which was
previously giving import error.

Signed-off-by: ossdev07 <ossdev@puresoftware.com>