### PR TITLE
Licensing clarifications

### DIFF
--- a/AUTHORS.google-crc32c
+++ b/AUTHORS.google-crc32c
@@ -1,0 +1,10 @@
+# This is the list of Google's CRC32C authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+Google Inc.
+
+Fangming Fang <Fangming.Fang@arm.com>
+Vadim Skipin <vadim.skipin@gmail.com>
+Rodrigo Tobar <rtobar@icrar.org>

--- a/LICENSE.google-crc32c
+++ b/LICENSE.google-crc32c
@@ -1,0 +1,28 @@
+Copyright 2017, The CRC32C Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE.slice-by-8
+++ b/LICENSE.slice-by-8
@@ -1,0 +1,42 @@
+Copyright (c) 2008,2009,2010 Massachusetts Institute of Technology.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of the Massachusetts Institute of Technology nor
+  the names of its contributors may be used to endorse or promote
+  products derived from this software without specific prior written
+  permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Other portions are under the same license from Intel:
+http://sourceforge.net/projects/slicing-by-8/
+/*++
+ *
+ * Copyright (c) 2004-2006 Intel Corporation - All Rights Reserved
+ *
+ * This software program is licensed subject to the BSD License, 
+ * available at http://www.opensource.org/licenses/bsd-license.html
+ *
+ * Abstract: The main routine
+ * 
+ --*/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include *.h
+include LICENSE*
+include AUTHORS*

--- a/README.rst
+++ b/README.rst
@@ -66,11 +66,21 @@ to one of the following values:
 * ``none``: fail to import the module with an ``ImportError``
   if no hardware support is found (old 1.x default behavior).
 
-Both the hardware- (Intel) and software-based algorithms
-are based on `Mark Adler's code <http://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software/17646775>`_,
+The software algorithm is based
+on Intel's `slice-by-8 package <https://sourceforge.net/projects/slicing-by-8/>`_,
+with some adaptations done
+by `Evan Jones <https://www.evanjones.ca/crc32c.html>`_
+and packaging provided by `Ferry Toth <https://github.com/htot/crc32c>`_.
+Further adaptations were required
+to make the code more portable
+and fit for inclusion within this python package.
+
+The Intel SSE 4.2 algorithm
+is based on `Mark Adler's code <http://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software/17646775>`_,
 with some modifications required
 to make the code more portable
 and fit for inclusion within this python package.
+
 The ARMv8 hardware implementation
 is based on Google's `crc32c <https://github.com/google/crc32c>`_
 C++ library.
@@ -84,9 +94,19 @@ This package is copyrighted::
  (c) UWA - The University of Western Australia, 2017
  Copyright by UWA (in the framework of the ICRAR)
 
-The original crc32c algorithms,
-both software and Intel-hardware,
+The original slice-by-8 software algorithm
+is copyrighted by::
+
+ Copyright (c) 2004-2006 Intel Corporation - All Rights Reserved
+
+Further adaptations to the slice-by-8 algorithm
+previous to the inclusion in this package
 are copyrighted by::
+
+ Copyright 2008,2009,2010 Massachusetts Institute of Technology.
+
+The original Intel SSE 4.2 crc32c algorithm
+is copyrighted by::
 
  Copyright (C) 2013 Mark Adler
 
@@ -95,18 +115,26 @@ is copyrighted by::
 
  Copyright 2017 The CRC32C Authors
 
+A copy of the `AUTHORS <AUTHORS.google-crc32c>`_ file
+from Google's crc32c project
+as it was at the time of copying the code
+is included in this repository.
 
 License
 -------
 
-This package is licensed under the LGPL-2.1 license.
+This package is licensed under `the LGPL-2.1 license <LICENSE>`_.
 
-The original crc32c code,
-both software and for Intel SSE4.2 machines,
-are licensed under the BSD 3-clause license.
+The original slice-by-8 software algorithm
+is licensed under `the 2-clause BSD licence
+<https://opensource.org/licenses/bsd-license.html>`_.
 
-The original crc32c code
-for ARM64 machines
-is licensed under a BSD-style license
-that can be found in the LICENSE file
-of Google's `crc32c <https://github.com/google/crc32c>`_.
+Further modifications to the slice-by-8 software algorithm
+are licensed under `a 3-clause BSD licence <LICENSE.slice-by-8>`_
+
+The original Intel SSE 4.2 crc32c algorithm's code
+is licensed under a custom license
+embedded in the ``crc32c_adler.c`` file.
+
+The original crc32c ARMv8 hardware code
+is licensed under `a 3-clause BSD license <LICENSE.google-crc32c>`_.

--- a/crc32c_arm64.c
+++ b/crc32c_arm64.c
@@ -1,6 +1,7 @@
 // Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file. See the AUTHORS file for names of contributors.
+// found in the LICENSE.google-crc32c file. See the AUTHORS.google-crc32c file
+// for names of contributors.
 
 // In a separate source file to allow this accelerated CRC32C function to be
 // compiled with the appropriate compiler flags to enable ARM NEON CRC32C

--- a/crc32c_sw.c
+++ b/crc32c_sw.c
@@ -1,6 +1,6 @@
 // Copyright 2008,2009,2010 Massachusetts Institute of Technology.
 // All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
+// BSD-style license that can be found in the LICENSE.slice-by-8 file.
 
 // Implementations adapted from Intel's Slicing By 8 Sourceforge Project
 // http://sourceforge.net/projects/slicing-by-8/


### PR DESCRIPTION
These are a few modifications that try to improve the licensing/author referencing situation of our package. Missing licenses have been added and they are being now referenced from the code and the `README.rst` file. Likewise with Google's `AUTHORS` file. Overall, the story of how each pice of external code came to be has been much improved.