### PR TITLE
HWCAP_CRC32 is already defined on arm64

### DIFF
--- a/checkarm.c
+++ b/checkarm.c
@@ -26,10 +26,13 @@
 
 #include <sys/auxv.h>
 
+#ifndef HWCAP_CRC32
+/* see arch/arm64/include/uapi/asm/hwcap.h */
+#define HWCAP_CRC32 (1 << 7)
+#endif
+
 int _crc32c_arm64_probe(void)
 {
-	/* see arch/arm64/include/uapi/asm/hwcap.h */
-	const unsigned long HWCAP_CRC32 = 1 << 7;
 	unsigned long auxval;
 	auxval = getauxval(AT_HWCAP);
 	return (auxval & HWCAP_CRC32) != 0;


### PR DESCRIPTION
On a standard GNU/Linux system, `<sys/auxv.h>` includes `<bits/hwcap.h>` which defines `HWCAP_CRC32`.

We probably have no need for a fallback, I'm sure anyone using this library will have `HWCAP_CRC32` defined, but it doesn't really hurt to carry it, either...

Before this patch, the C compiler was understandably upset:

```
checkarm.c: In function ‘_crc32c_arm64_probe’:
checkarm.c:32:22: error: expected identifier or ‘(’ before numeric constant
   32 |  const unsigned long HWCAP_CRC32 = 1 << 7;
      |                      ^~~~~~~~~~~
```