### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(name='crc32c',
       url='https://github.com/ICRAR/crc32c',
       author_email='rtobar@icrar.org',
       version='2.3.post0',
-      license="LGPLv2.1+",
+      license="LGPL-2.1-or-later",
       description=('A python package implementing the crc32c algorithm'
       ' in hardware and software'),
       long_description=long_description,


### PR DESCRIPTION
Use SPDX license identifier: LGPL-2.1-or-later
This will help tools to produce valid SPDX.