### PR TITLE
Release GIL when doing the compute-intensive CRC computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Development
 
+* Release GIL during the computation of the CRC32C hash. A new `gil_release_mode` argument lets users choose between always/never/automatically releasing it (#47).
+* Add keyword support to `crc32c` function (`crc32c(data, value=0, gil_release_mode=-1)`).
 * Adding explicit fallthrough annotations
   in several ``switch`` C statements
   for clarity, and to avoid potential warnings (#46).

--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,9 @@ by older compiler versions.
 Usage
 -----
 
-The only method exposed by this module is ``crc32c(data, [crc])``.
+The only method exposed by this module is ``crc32c(data, value=0, gil_release_mode=-1)``.
 It computes the CRC32C checksum of ``data``
-starting with an initial ``crc`` checksum,
+starting with an initial ``value`` checksum,
 similarly to how the built-in ``binascii.crc32`` works.
 It can thus be used like this:
 
@@ -40,13 +40,21 @@ It can thus be used like this:
   print(crc32c.crc32c(b'hello world'))
   # 3381945770
   crc = crc32c.crc32c(b'hello')
-  print(crc32c.crc32c(b' world', crc))
+  print(crc32c.crc32c(b' world', value=crc))
   # 3381945770
 
 In older versions,
 the function exposed by this module was called ``crc32``.
 That name is still present but deprecated,
 and will be removed in new versions of the library.
+
+The ``gil_release_mode`` keyword argument
+specifies whether a call of this library shall release or keep the Global Interpreter Lock.
+It can be set to the following values:
+
+* Negative: Only release the GIL when ``data`` >= 32KiB
+* 0: Never release the GIL
+* Positive: Always release the GIL
 
 Additionally one can consult
 the following module-level values:

--- a/test/test_crc32c.py
+++ b/test/test_crc32c.py
@@ -80,6 +80,19 @@ class TestMisc(unittest.TestCase):
     def test_zero(self):
         self.assertEqual(0, crc32c.crc32c(b''))
 
+    def test_keyword(self):
+        self.assertEqual(10, crc32c.crc32c(b'', value=10))
+
+    def test_gil_behaviour(self):
+        def _test(data):
+            expected = crc32c.crc32c(data)
+            self.assertEqual(crc32c.crc32c(data, gil_release_mode=-1), expected)
+            self.assertEqual(crc32c.crc32c(data, gil_release_mode=0), expected)
+            self.assertEqual(crc32c.crc32c(data, gil_release_mode=1), expected)
+
+        _test(b'this_doesnt_release_the_gil_by_default')
+        _test(b'this_releases_the_gil_by_default' * 1024 * 1024)
+
     def test_crc32_deprecated(self):
         with warning_catcher() as warns:
             crc32c.crc32(b'')


### PR DESCRIPTION
Unfortunately, this library captures the Python GIL for the entirety of its computation. I chose this library because it's quite fast compared to others, but this is pretty worthless if it's forcing one to use multiprocessing for a realtively mundane task such as computing a hash of a given bytebuffer.

I think this should work. On a very simply test benchmark, I saw a sizeable performance improvement using this fork (~46s vs. ~8s using 16 threads on my 13th Gen Intel(R) Core(TM) i7-1370P):
```
import crc32c
import concurrent.futures
import io
import time


def calc_crc(inp: io.BytesIO) -> int:
    return crc32c.crc32c(inp.getbuffer())


N_DATA = 1_000_000_000
N_COUNT = 1000

data = io.BytesIO(b"0"*N_DATA)

ts = time.perf_counter()
res = [calc_crc(data) for _ in range(N_COUNT)]
te = time.perf_counter()
print(te-ts)  # 46.33s


with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
    ts = time.perf_counter()
    res_threaded = list(executor.map(calc_crc, [data for _ in range(N_COUNT)]))
    te = time.perf_counter()
    print(te-ts)  # 8.02s
    assert res == res_threaded
```

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the CRC computation by releasing the GIL during the compute-intensive operation, resulting in significant performance improvements in multi-threaded scenarios.

Enhancements:
- Release the Global Interpreter Lock (GIL) during the compute-intensive CRC computation to improve performance in multi-threaded environments.

<!-- Generated by sourcery-ai[bot]: end summary -->