### PR TITLE
Make package PEP 561 compliant; add typehint stub file

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+  schedule:
+  # 00:00 UTC every Saturday, don't bother anyone
+  - cron: '0 0 * * 6'
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11.8
+          architecture: x64
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install mypy & wheel
+        run: pip install mypy wheel
+      - name: Install package
+        run: python setup.py bdist_wheel && pip install dist/crc32c*.whl
+      - name: Run mypy
+        run: mypy --strict test/test_crc32c.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Development
 
+* Made this package PEP 561 compliant (#49).
 * Release GIL during the computation of the CRC32C hash. A new `gil_release_mode` argument lets users choose between always/never/automatically releasing it (#47).
 * Add keyword support to `crc32c` function (`crc32c(data, value=0, gil_release_mode=-1)`).
 * Turned ``crc32c`` from a module-only distribution into a package,

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include LICENSE*
 include AUTHORS*
 include src/crc32c/ext/*.h
+include src/crc32c/*.pyi
+include src/crc32c/py.typed

--- a/setup.py
+++ b/setup.py
@@ -67,5 +67,6 @@ setup(name='crc32c',
       classifiers=classifiers,
       packages=['crc32c'],
       package_dir={'': 'src'},
+      include_package_data=True,
       ext_modules=[crcmod_ext],
       test_suite="test")

--- a/src/crc32c/__init__.pyi
+++ b/src/crc32c/__init__.pyi
@@ -1,0 +1,7 @@
+from collections.abc import Buffer
+
+big_endian: int
+hardware_based: bool
+
+def crc32(data: Buffer, value: int = 0, gil_release_mode: int = -1) -> int: ...
+def crc32c(data: Buffer, value: int = 0, gil_release_mode: int = -1) -> int: ...


### PR DESCRIPTION
Has to be merged after https://github.com/ICRAR/crc32c/pull/47.
Makes this package properly PEP 561 compliant by introducing a `py.typed` and stub files for the underlying C extension.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Make the package PEP 561 compliant by adding type hint stub files and updating `setup.py` to include package data.

New Features:
- Introduce type hint stub file `crc32c/__init__.pyi` for the underlying C extension.

Enhancements:
- Make the package PEP 561 compliant by adding a `py.typed` file and including package data in `setup.py`.

<!-- Generated by sourcery-ai[bot]: end summary -->