### PR TITLE
Add Windows ARM64 build

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2025, macos-14]
+        os: [ubuntu-22.04, windows-2025, windows-11-arm, macos-14]
         arch: [auto]
         include:
           - os: ubuntu-22.04


### PR DESCRIPTION
As the title says. The build config was pretty neat already so just had to add a Windows ARM64 runner there.

Note that I have not looked into HW accel on Windows ARM64, as that seems to be gated to Linux anyway, and not available on macOS ARM64 either.

## Summary by Sourcery

Expand release builds to support Windows ARM64.

New Features:
- Add Windows ARM64 to the supported build and release targets.

Build:
- Extend the build matrix with a Windows ARM runner.