### PR TITLE
workflows: build_and_release: add riscv64

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -19,6 +19,8 @@ jobs:
         include:
           - os: ubuntu-22.04
             arch: aarch64
+          - os: ubuntu-24.04-riscv
+            arch: riscv64
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Make use of RISE's Native RISC-V Runners to build crc32c for riscv64. This requires enabling them for the repository as a GitHub Application. More info is available here: https://riscv-runners.riseproject.dev/

I tried a test run on my fork. You can review the results here: https://github.com/threexc/crc32c/pull/1

This is being done on behalf of [RISE](https://riseproject.dev/), using the [RISC-V Wheels](https://stanfromireland.github.io/riscv-wheels/) dashboard to track upstream support for the Python ecosystem.

## Summary by Sourcery

Build and release crc32c for riscv64 using native RISC-V runners.

New Features:
- Add riscv64 to the release build matrix using Ubuntu 24.04 RISC-V runners.

Build:
- Extend the GitHub Actions build and release workflow to produce riscv64 builds.